### PR TITLE
feat(azure): 11.1 SWA deploy docs + SPA fallback

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,8 @@
+
+## 11.1 — Frontend on Azure Static Web Apps
+
+- Resource: **bike-frontend** (Free, Region: West Europe)
+- Branch: **main**
+- App location: `/` • Output: `dist` • API: *(empty)*
+- URL: https://kind-river-099ad551e.2.azurestaticapps.net
+- Notes: SPA fallback via `staticwebapp.config.json` to prevent 404 on deep links.

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,3 @@
+{
+  "navigationFallback": { "rewrite": "/index.html" }
+}


### PR DESCRIPTION
closes #34 

**Summary**
Initial deploy of frontend to Azure Static Web Apps wired to GitHub (`main`).

**Live**
https://kind-river-099ad551e.2.azurestaticapps.net

**Build config**
app: `/` • output: `dist` • api: (empty)

**Changes**
- Add `staticwebapp.config.json` with `navigationFallback -> /index.html`.
- Add brief deploy notes to `DEPLOY.md` (resource, region, URL).

**Evidence**
- Azure SWA Overview (screenshot)

<img width="1509" height="600" alt="image" src="https://github.com/user-attachments/assets/4e314718-5479-4a07-a0bf-dc95b772be88" />

- GitHub Actions run (green) (screenshot)

<img width="1239" height="622" alt="image" src="https://github.com/user-attachments/assets/49ddb863-edc6-4732-80d0-8493fe3fcd53" />

- Live URL opened (screenshot)

<img width="874" height="541" alt="image" src="https://github.com/user-attachments/assets/f95d8124-1b59-4900-9488-d350bb3ce5dd" />

**Known**
White page currently (raw `index.html` served). Will fix in 11.2 (#35) by building with Vite and uploading `dist` (and `base: '/'`).
